### PR TITLE
Provider and sublayer filtering

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,13 +88,17 @@ int main(int argc, char** argv)
             const auto &listValues = result["list"].as<std::vector<std::string>>();
             bool shouldShowAllFilters = std::ranges::find(listValues, "all") != listValues.end();
 
-            std::vector<std::regex> providers;
+            std::vector<std::regex> providers, subLayers;
 
             if(!shouldShowAllFilters)
+            {
+                // We match the 'names' against both providers and subLayers
+                // so that both fields are searched
                 providers = stringVecToMatchers(listValues);
+                subLayers = providers;
+            }
 
             const auto layers = stringVecToMatchers({result["layer"].as<std::vector<std::string>>()});
-            const auto subLayers = stringVecToMatchers(result["sublayer"].as<std::vector<std::string>>());
             wfpKiller.listFilters({
                 .providerMatchers = providers,
                 .layerMatchers = layers,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,12 +138,12 @@ int main(int argc, char** argv)
     }
     catch(const wfpk::WfpError& ex)
     {
-        std::cerr << "Fatal WFP error: " << ex.what() << " Unable to continue.\n";
+        std::cerr << "Fatal WFP error: " << ex.what() << "\n";
         return 1;
     }
     catch(const std::exception &ex)
     {
-        std::cerr << "Fatal error: " << ex.what() << " Unable to continue.\n";
+        std::cerr << "Fatal error: " << ex.what() << "\n";
         return 1;
     }
     catch(...)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,9 @@ int main(int argc, char** argv)
             ("h,help", "Display this help message.")
             ("l,list", "List all PIA filters.")
             ("m,monitor", "Monitor WFP events.")
+            ("p,provider", "Limit output to a specific provider (accepts partial name match)", cxxopts::value<std::vector<std::string>>()->default_value({}))
+            ("L,layer", "Limit output to a specific layer (accepts partial name match)", cxxopts::value<std::vector<std::string>>()->default_value({}))
+            ("s,sublayer", "Limit output to a specified sublayer (accepts partial name match)", cxxopts::value<std::vector<std::string>>()->default_value({}))
             ("d,delete", "Delete a filter or all filters (takes a filter ID or 'all').", cxxopts::value<std::vector<std::string>>());
 
         wfpk::WfpKiller wfpKiller;
@@ -63,7 +66,14 @@ int main(int argc, char** argv)
         }
         else if(result.count("list"))
         {
-            wfpKiller.listFilters();
+            const auto providers = result["provider"].as<std::vector<std::string>>();
+            const auto layers = result["layer"].as<std::vector<std::string>>();
+            const auto subLayers = result["sublayer"].as<std::vector<std::string>>();
+            wfpKiller.listFilters({
+                .providers = providers,
+                .layers = layers,
+                .subLayers = subLayers
+             });
             return 0;
         }
         else if(result.count("delete"))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,10 +64,10 @@ int main(int argc, char** argv)
 
     try
     {
-        options.allow_unrecognised_options();
+        //options.allow_unrecognised_options();
         options.add_options()
             ("h,help", "Display this help message.")
-            ("l,list", "List all filters across all layers (also accepts an optional partial name match for a provider name).", cxxopts::value<std::vector<std::string>>())
+            ("l,list", "List all filters across all layers (also accepts an optional partial name match for a provider or 'all').", cxxopts::value<std::vector<std::string>>())
             ("m,monitor", "Monitor WFP events.")
             ("p,provider", "Limit output to a specific provider (accepts partial name match).", cxxopts::value<std::vector<std::string>>()->default_value({}))
             ("L,layer", "Limit output to a specific layer (accepts partial name match).", cxxopts::value<std::vector<std::string>>()->default_value({}))
@@ -85,11 +85,15 @@ int main(int argc, char** argv)
         }
         else if(result.count("list"))
         {
-            const auto providers = stringVecToMatchers(result["list"].as<std::vector<std::string>>());
-            std::cout << "Number of list options: " << providers.size() << std::endl;
+            const auto &listValues = result["list"].as<std::vector<std::string>>();
+            bool shouldShowAllFilters = std::ranges::find(listValues, "all") != listValues.end();
 
-            //const auto providers = stringVecToMatchers(result["provider"].as<std::vector<std::string>>());
-            const auto layers = stringVecToMatchers(result["layer"].as<std::vector<std::string>>());
+            std::vector<std::regex> providers;
+
+            if(!shouldShowAllFilters)
+                providers = stringVecToMatchers(listValues);
+
+            const auto layers = stringVecToMatchers({result["layer"].as<std::vector<std::string>>()});
             const auto subLayers = stringVecToMatchers(result["sublayer"].as<std::vector<std::string>>());
             wfpKiller.listFilters({
                 .providerMatchers = providers,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,11 +67,11 @@ int main(int argc, char** argv)
         options.allow_unrecognised_options();
         options.add_options()
             ("h,help", "Display this help message.")
-            ("l,list", "List all filters across all layers.")
+            ("l,list", "List all filters across all layers (also accepts an optional partial name match for a provider name).", cxxopts::value<std::vector<std::string>>())
             ("m,monitor", "Monitor WFP events.")
-            ("p,provider", "Limit output to a specific provider (accepts partial name match)", cxxopts::value<std::vector<std::string>>()->default_value({}))
-            ("L,layer", "Limit output to a specific layer (accepts partial name match)", cxxopts::value<std::vector<std::string>>()->default_value({}))
-            ("s,sublayer", "Limit output to a specified sublayer (accepts partial name match)", cxxopts::value<std::vector<std::string>>()->default_value({}))
+            ("p,provider", "Limit output to a specific provider (accepts partial name match).", cxxopts::value<std::vector<std::string>>()->default_value({}))
+            ("L,layer", "Limit output to a specific layer (accepts partial name match).", cxxopts::value<std::vector<std::string>>()->default_value({}))
+            ("s,sublayer", "Limit output to a specified sublayer (accepts partial name match).", cxxopts::value<std::vector<std::string>>()->default_value({}))
             ("d,delete", "Delete a filter or all filters (takes a filter ID or 'all').", cxxopts::value<std::vector<std::string>>());
 
         wfpk::WfpKiller wfpKiller;
@@ -85,7 +85,10 @@ int main(int argc, char** argv)
         }
         else if(result.count("list"))
         {
-            const auto providers = stringVecToMatchers(result["provider"].as<std::vector<std::string>>());
+            const auto providers = stringVecToMatchers(result["list"].as<std::vector<std::string>>());
+            std::cout << "Number of list options: " << providers.size() << std::endl;
+
+            //const auto providers = stringVecToMatchers(result["provider"].as<std::vector<std::string>>());
             const auto layers = stringVecToMatchers(result["layer"].as<std::vector<std::string>>());
             const auto subLayers = stringVecToMatchers(result["sublayer"].as<std::vector<std::string>>());
             wfpKiller.listFilters({

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -52,4 +52,15 @@ std::string wideStringToString(const std::wstring &wstr)
 
     return str;
 }
+
+std::string toLowercase(const std::string &str)
+{
+    std::string ret;
+    ret.reserve(str.size());
+    for(unsigned char c : str)
+        ret.push_back(std::tolower(c));
+
+        return ret;
+}
+
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -63,4 +63,33 @@ std::string toLowercase(const std::string &str)
         return ret;
 }
 
+std::string getErrorString(DWORD errorCode)
+{
+    LPSTR errMsg = nullptr;
+    DWORD flags = FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS;
+
+    DWORD messageLength = FormatMessageA(
+        flags,                 // Use system message tables to retrieve error text
+        nullptr,               // No module handle is necessary
+        errorCode,             // Pass in the error code to look up
+        0,                     // Automatically choose the correct language
+        (LPSTR)&errMsg,        // Buffer that will receive the error message
+        0,                     // Minimum number of characters to allocate for errMsg
+        nullptr                // No varargs for additional error-specific inserts
+    );
+
+    if(messageLength == 0)
+    {
+        // Handle the case where there is no error message found
+        return "Unknown error code: " + std::to_string(errorCode);
+    }
+
+    std::string errorMessage(errMsg);
+
+    // Free the buffer allocated by FormatMessage
+    LocalFree(errMsg);
+
+    return errorMessage;
+}
+
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -9,6 +9,8 @@
 #include <vector>
 #include <optional>
 #include <memory>
+#include <ranges>
+#include <concepts>
 #include <guiddef.h>
 #include <assert.h>
 
@@ -47,6 +49,8 @@ std::string blobToString(const FWP_BYTE_BLOB &blob);
 std::string wideStringToString(const std::wstring &wstr);
 // Convert a GUID to a std::string
 std::string guidToString(const GUID& guid);
+// Lowercase a string
+std::string toLowercase(const std::string& input);
 
 void fwpConditionValueHandler(const FWP_CONDITION_VALUE &value, auto handlerFunc)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -52,6 +52,8 @@ std::string guidToString(const GUID& guid);
 // Lowercase a string
 std::string toLowercase(const std::string& input);
 
+std::string getErrorString(DWORD errorCode);
+
 void fwpConditionValueHandler(const FWP_CONDITION_VALUE &value, auto handlerFunc)
 {
     switch(value.type)

--- a/src/wfp_killer.cpp
+++ b/src/wfp_killer.cpp
@@ -100,7 +100,7 @@ bool WfpKiller::deleteSingleFilter(FilterId filterId) const
     DWORD result = _engine.deleteFilterById(filterId);
     if(result != ERROR_SUCCESS)
     {
-        std::cerr << std::format("Error: Failed to delete filter with id {} Code: {}\n", filterId, result);
+        std::cerr << std::format("Error: Failed to delete filter with id {}: {}\n", filterId, getErrorString(result));
         return false;
     }
     else

--- a/src/wfp_killer.cpp
+++ b/src/wfp_killer.cpp
@@ -1,4 +1,7 @@
 #include <format>
+#include <ranges>
+#include <algorithm>
+#include <string>
 #include <windows.h>
 #include <stdlib.h>
 #include "wfp_killer.h"
@@ -20,18 +23,46 @@ namespace
         FWPM_LAYER_INBOUND_IPPACKET_V4,
         FWPM_LAYER_OUTBOUND_IPPACKET_V4
     };
+
+    using Options = WfpKiller::Options;
+
+    bool caseInsensitiveMatch(const std::string& matchStr, const std::string& fullStr)
+    {
+        if(matchStr.empty() || fullStr.empty())
+            return false;
+
+        auto matchIter = matchStr.begin();
+        for(auto ch : fullStr | std::views::transform(tolower))
+        {
+            if(matchIter == matchStr.end()) break; // All chars in matchStr found
+            if(ch == std::tolower(*matchIter))
+            {
+                ++matchIter; // Move to the next char in matchStr
+            }
+        }
+        return matchIter == matchStr.end(); // True if all chars were matched
+    }
 }
 
-void WfpKiller::listFilters() const
+void WfpKiller::listFilters(const Options &options) const
 {
     size_t filterCount{0};
-
-    std::cout << "Showing all filters for PIA provider:\n";
 
     for(const auto &layerKey : kPiaLayers)
     {
         std::cout << std::format("\nLayer: {}\n", WfpNameMapper::getName(layerKey).rawName);
         _engine.enumerateFiltersForLayer(layerKey, [&](const auto &pFilter) {
+            if(options.providers.size())
+            {
+                // Skip empty providers - we only want to show filters
+                // with a provider and whose provider matches one in our list
+                if(!pFilter->providerKey)
+                    return;
+
+                if(!isProviderMatched(options.providers, *pFilter->providerKey))
+                    return;
+            }
+
             std::cout << *pFilter << std::endl;
             ++filterCount;
         });
@@ -72,6 +103,7 @@ void WfpKiller::deleteFilters(const std::vector<FilterId> &filterIds) const
 
 void WfpKiller::monitor()
 {
+    std::cout << "Monitoring network events - press enter or Ctrl+C to stop.\n";
     _engine.monitorEvents([](void *context, const FWPM_NET_EVENT *event) {
         std::cout << *event << "\n";
     });
@@ -93,4 +125,17 @@ bool WfpKiller::deleteSingleFilter(FilterId filterId) const
         return true;
     }
 }
+
+bool WfpKiller::isProviderMatched(const std::vector<std::string> &providerMatchers, const GUID &providerKey) const
+{
+    std::unique_ptr<FWPM_PROVIDER, WfpDeleter> pProvider{_engine.getProviderByKey(providerKey)};
+    std::string providerName = wideStringToString(pProvider->displayData.name);
+
+    bool isProviderMatch = std::ranges::any_of(providerMatchers, [&](const auto &providerMatcher) {
+        return caseInsensitiveMatch(providerMatcher, providerName);
+    });
+
+    return isProviderMatch;
+}
+
 }

--- a/src/wfp_killer.h
+++ b/src/wfp_killer.h
@@ -1,19 +1,29 @@
 #pragma once
 
 #include "wfp_objects.h"
+#include <string>
+#include <vector>
 
 namespace wfpk {
-
 // Core application class
 class WfpKiller
 {
 public:
-    void listFilters() const;
+    struct Options
+    {
+        std::vector<std::string> providers;
+        std::vector<std::string> layers;
+        std::vector<std::string> subLayers;
+    };
+
+public:
+    void listFilters(const Options &options) const;
     void deleteFilters(const std::vector<FilterId> &filterIds) const;
     void monitor();
 
 private:
     bool deleteSingleFilter(FilterId filterId) const;
+    bool isProviderMatched(const std::vector<std::string> &providerMatchers, const GUID &providerKey) const;
 
 private:
     Engine _engine;

--- a/src/wfp_killer.h
+++ b/src/wfp_killer.h
@@ -24,7 +24,7 @@ public:
 
 private:
     bool deleteSingleFilter(FilterId filterId) const;
-    bool isProviderMatched(const std::vector<std::regex> &providerMatchers, const GUID &providerKey) const;
+    bool isProviderMatched(const std::vector<std::regex> &providerMatchers, const GUID *pProviderKey) const;
 
 private:
     Engine _engine;

--- a/src/wfp_killer.h
+++ b/src/wfp_killer.h
@@ -30,6 +30,7 @@ public:
 private:
     bool deleteSingleFilter(FilterId filterId) const;
     bool isNameMatched(const std::vector<std::regex> &matchers, const std::string &name) const;
+    bool isFilterNameMatched(const std::vector<std::regex> &matchers, const std::shared_ptr<FWPM_FILTER> &pFilter) const;
 
 private:
     Engine _engine;

--- a/src/wfp_killer.h
+++ b/src/wfp_killer.h
@@ -15,6 +15,11 @@ public:
         std::vector<std::regex> providerMatchers;
         std::vector<std::regex> layerMatchers;
         std::vector<std::regex> subLayerMatchers;
+
+        bool isEmpty() const
+        {
+            return providerMatchers.empty() && layerMatchers.empty() && subLayerMatchers.empty();
+        }
     };
 
 public:
@@ -24,7 +29,7 @@ public:
 
 private:
     bool deleteSingleFilter(FilterId filterId) const;
-    bool isProviderMatched(const std::vector<std::regex> &providerMatchers, const GUID *pProviderKey) const;
+    bool isNameMatched(const std::vector<std::regex> &matchers, const std::string &name) const;
 
 private:
     Engine _engine;

--- a/src/wfp_killer.h
+++ b/src/wfp_killer.h
@@ -3,6 +3,7 @@
 #include "wfp_objects.h"
 #include <string>
 #include <vector>
+#include <regex>
 
 namespace wfpk {
 // Core application class
@@ -11,9 +12,9 @@ class WfpKiller
 public:
     struct Options
     {
-        std::vector<std::string> providers;
-        std::vector<std::string> layers;
-        std::vector<std::string> subLayers;
+        std::vector<std::regex> providerMatchers;
+        std::vector<std::regex> layerMatchers;
+        std::vector<std::regex> subLayerMatchers;
     };
 
 public:
@@ -23,7 +24,7 @@ public:
 
 private:
     bool deleteSingleFilter(FilterId filterId) const;
-    bool isProviderMatched(const std::vector<std::string> &providerMatchers, const GUID &providerKey) const;
+    bool isProviderMatched(const std::vector<std::regex> &providerMatchers, const GUID &providerKey) const;
 
 private:
     Engine _engine;

--- a/src/wfp_name_mapper.cpp
+++ b/src/wfp_name_mapper.cpp
@@ -29,6 +29,9 @@ namespace
         WFP_NAME(FWPM_CONDITION_IP_LOCAL_ADDRESS, "local_ip"),
         WFP_NAME(FWPM_CONDITION_IP_LOCAL_PORT, "local_port"),
         WFP_NAME(FWPM_CONDITION_IP_LOCAL_INTERFACE, "local_interface"),
+        WFP_NAME(FWPM_CONDITION_IP_PROTOCOL, "protocol"),
+        WFP_NAME(FWPM_CONDITION_INTERFACE_TYPE, "interface_type"),
+        WFP_NAME(FWPM_CONDITION_INTERFACE_INDEX, "interface_index")
     };
 
     // Match types, see full list here: https://learn.microsoft.com/en-us/windows/win32/api/fwptypes/ne-fwptypes-fwp_match_type
@@ -37,7 +40,11 @@ namespace
         WFP_NAME(FWP_MATCH_GREATER, "greater"),
         WFP_NAME(FWP_MATCH_LESS, "less than"),
         WFP_NAME(FWP_MATCH_GREATER_OR_EQUAL, "great or equal"),
-        WFP_NAME(FWP_MATCH_LESS_OR_EQUAL, "less or equal")
+        WFP_NAME(FWP_MATCH_LESS_OR_EQUAL, "less or equal"),
+        WFP_NAME(FWP_MATCH_RANGE, "range match"),
+        WFP_NAME(FWP_MATCH_NOT_EQUAL, "not equal"),
+        WFP_NAME(FWP_MATCH_PREFIX, "prefix equal"),
+        WFP_NAME(FWP_MATCH_NOT_PREFIX, "prefix not equal")
     };
 
     // IP Version types, see full list here: https://learn.microsoft.com/en-us/windows/win32/api/fwptypes/ne-fwptypes-fwp_ip_version

--- a/src/wfp_name_mapper.cpp
+++ b/src/wfp_name_mapper.cpp
@@ -8,7 +8,7 @@
 namespace wfpk {
 namespace
 {
-    #define WFP_NAME(rawName, friendlyName) { rawName, { friendlyName, #rawName } }
+    #define WFP_NAME(guid, friendlyName) { guid, { friendlyName, #guid } }
 
     const std::unordered_map<GUID, WfpName> kGuidWfpNameMap {
         // Layer names, see full list here: https://learn.microsoft.com/en-us/windows/win32/fwp/management-filtering-layer-identifiers-

--- a/src/wfp_objects.cpp
+++ b/src/wfp_objects.cpp
@@ -44,7 +44,7 @@ auto SingleLayerFilterEnum::createEnumTemplate(const GUID &layerKey) const
     FWPM_FILTER_ENUM_TEMPLATE enumTemplate{};
     enumTemplate.enumType = FWP_FILTER_ENUM_OVERLAPPING;
     enumTemplate.layerKey = layerKey;
-    enumTemplate.providerKey = const_cast<GUID*>(&PIA_PROVIDER_KEY);
+    enumTemplate.providerKey = NULL; // const_cast<GUID*>(&PIA_PROVIDER_KEY);
     enumTemplate.actionMask = 0xFFFFFFFF;
 
     return enumTemplate;

--- a/src/wfp_objects.cpp
+++ b/src/wfp_objects.cpp
@@ -18,7 +18,7 @@ Engine::Engine()
     DWORD result = FwpmEngineOpen(NULL, RPC_C_AUTHN_WINNT, NULL, NULL, &_handle);
     if(result != ERROR_SUCCESS)
     {
-        throw WfpError{"FwpmEngineOpen failed, code: " + result};
+        throw WfpError{"FwpmEngineOpen failed, code:", result};
     }
 }
 
@@ -34,7 +34,7 @@ Engine::~Engine()
     if(result != ERROR_SUCCESS)
     {
         // Cannot throw in a destructor
-        std::cerr << "FwpmEngineClose failed, code: " << result;
+        std::cerr << "FwpmEngineClose failed: " << getErrorString(result);
     }
 }
 
@@ -61,7 +61,7 @@ SingleLayerFilterEnum::SingleLayerFilterEnum(const GUID &layerKey, HANDLE engine
     result = FwpmFilterCreateEnumHandle(_engineHandle, &enumTemplate, &enumHandle);
     if(result != ERROR_SUCCESS)
     {
-        throw WfpError{"FwpmFilterCreateEnumHandle failed: " + result};
+        throw WfpError{"FwpmFilterCreateEnumHandle failed:", result};
     }
 
     FWPM_FILTER **pFilters{nullptr};
@@ -70,7 +70,7 @@ SingleLayerFilterEnum::SingleLayerFilterEnum(const GUID &layerKey, HANDLE engine
     result = FwpmFilterEnum(_engineHandle, enumHandle, MaxFilterCount, &pFilters, &numEntries);
     if(result != ERROR_SUCCESS)
     {
-        throw WfpError{"FwpmFilterEnum failed: " + result};
+        throw WfpError{"FwpmFilterEnum failed:", result};
     }
 
     for(size_t i = 0; i < numEntries; ++i)
@@ -82,7 +82,7 @@ SingleLayerFilterEnum::SingleLayerFilterEnum(const GUID &layerKey, HANDLE engine
         if(result == ERROR_SUCCESS)
             _pFilters.insert(std::shared_ptr<FWPM_FILTER>{pFilter, WfpDeleter{}});
         else
-            std::cerr << "FwpmFilterGetById failed, code: " << std::to_string(result) << std::endl;
+            std::cerr << "FwpmFilterGetById failed: " << getErrorString(result) << std::endl;
     }
 
     // Free the enum filters since we have shared_ptrs to new ones now anyway
@@ -92,7 +92,7 @@ SingleLayerFilterEnum::SingleLayerFilterEnum(const GUID &layerKey, HANDLE engine
     if(result != ERROR_SUCCESS)
     {
         // Just showing the error - we have the filters already, so let's give it a chance
-        std::cerr << "FwpmFilterDestroyEnumHandle failed, code: " + result << std::endl;
+        std::cerr << "FwpmFilterDestroyEnumHandle failed: " + getErrorString(result) << std::endl;
     }
 }
 }

--- a/src/wfp_objects.cpp
+++ b/src/wfp_objects.cpp
@@ -76,16 +76,17 @@ SingleLayerFilterEnum::SingleLayerFilterEnum(const GUID &layerKey, HANDLE engine
     for(size_t i = 0; i < numEntries; ++i)
     {
         FWPM_FILTER *pFilter{nullptr};
+
         // Grab a new filter so that we can carefully manage its lifetime
         DWORD result = FwpmFilterGetById(_engineHandle, pFilters[i]->filterId, &pFilter);
         if(result == ERROR_SUCCESS)
             _pFilters.insert(std::shared_ptr<FWPM_FILTER>{pFilter, WfpDeleter{}});
         else
-            std::cerr << "FwpmFilterGetById failed, code: " << result << std::endl;
+            std::cerr << "FwpmFilterGetById failed, code: " << std::to_string(result) << std::endl;
     }
 
     // Free the enum filters since we have shared_ptrs to new ones now anyway
-   FwpmFreeMemory(reinterpret_cast<void**>(&pFilters));
+    FwpmFreeMemory(reinterpret_cast<void**>(&pFilters));
     // Close the enumeration handle
     result = FwpmFilterDestroyEnumHandle(_engineHandle, enumHandle);
     if(result != ERROR_SUCCESS)

--- a/src/wfp_objects.h
+++ b/src/wfp_objects.h
@@ -149,6 +149,17 @@ public:
         return pSublayer;
     }
 
+    FWPM_PROVIDER* getProviderByKey(const GUID &providerKey) const
+    {
+        FWPM_PROVIDER *pProvider{nullptr};
+        DWORD result = FwpmProviderGetByKey(_handle, &providerKey, &pProvider);
+
+        if(result != ERROR_SUCCESS)
+            std::cerr << std::format("FwpmProviderGetByKey failed, code: {}\n", result);
+
+        return pProvider;
+    }
+
     // Iterate over all filters for all given layers
     template <typename IterFuncT>
         requires std::invocable<IterFuncT, std::shared_ptr<FWPM_FILTER>>

--- a/src/wfp_ostream_helpers.cpp
+++ b/src/wfp_ostream_helpers.cpp
@@ -61,9 +61,9 @@ std::ostream& operator<<(std::ostream& os, const FWPM_NET_EVENT& event)
     // pre-condition, an engine must exist
     assert(Engine::instance());
     // Grab a pointer to the applied filter
-    std::unique_ptr<FWPM_FILTER, WfpDeleter> pFilter{Engine::instance()->getFilterById(filterId)};
-    if(pFilter)
-        os << "\n    - (Filter applied: " << *pFilter << ")";
+     std::unique_ptr<FWPM_FILTER, WfpDeleter> pFilter{Engine::instance()->getFilterById(filterId)};
+     if(pFilter)
+         os << "\n    - (Filter applied: " << *pFilter << ")";
 
     return os;
 }

--- a/src/wfp_ostream_helpers.cpp
+++ b/src/wfp_ostream_helpers.cpp
@@ -70,13 +70,20 @@ std::ostream& operator<<(std::ostream& os, const FWPM_NET_EVENT& event)
 
 std::ostream& operator<<(std::ostream& os, const FWPM_FILTER& filter)
 {
-    if(filter.subLayerKey != ZeroGuid)
+    if(filter.providerKey)
+    {
+        std::unique_ptr<FWPM_PROVIDER, WfpDeleter> pProvider{Engine::instance()->getProviderByKey(*filter.providerKey)};
+        std::string providerName = wideStringToString(pProvider->displayData.name);
+        os << "Provider Name: " << providerName << " ";
+    }
+
+/*     if(filter.subLayerKey != ZeroGuid)
     {
         std::unique_ptr<FWPM_SUBLAYER, WfpDeleter> pSubLayer{Engine::instance()->getSubLayerByKey(filter.subLayerKey)};
         std::string subLayerName = wideStringToString(pSubLayer->displayData.name);
         os << "SubLayer: " << subLayerName << " ";
     }
-
+ */
     switch(filter.weight.type)
     {
     case FWP_EMPTY: // Weight managed by bfe

--- a/src/wfp_ostream_helpers.cpp
+++ b/src/wfp_ostream_helpers.cpp
@@ -70,20 +70,6 @@ std::ostream& operator<<(std::ostream& os, const FWPM_NET_EVENT& event)
 
 std::ostream& operator<<(std::ostream& os, const FWPM_FILTER& filter)
 {
-    if(filter.providerKey)
-    {
-        std::unique_ptr<FWPM_PROVIDER, WfpDeleter> pProvider{Engine::instance()->getProviderByKey(*filter.providerKey)};
-        std::string providerName = wideStringToString(pProvider->displayData.name);
-        os << "Provider Name: " << providerName << " ";
-    }
-
-/*     if(filter.subLayerKey != ZeroGuid)
-    {
-        std::unique_ptr<FWPM_SUBLAYER, WfpDeleter> pSubLayer{Engine::instance()->getSubLayerByKey(filter.subLayerKey)};
-        std::string subLayerName = wideStringToString(pSubLayer->displayData.name);
-        os << "SubLayer: " << subLayerName << " ";
-    }
- */
     switch(filter.weight.type)
     {
     case FWP_EMPTY: // Weight managed by bfe


### PR DESCRIPTION
Constrain filter list to those that match a given provider name or sublayer.

The match is case insensitive and allows partial matches, i.e `wfpkiller -p priv` will match the provider name `Private Internet Access Firewall`